### PR TITLE
Add color palette generator web app

### DIFF
--- a/july-2025/xpander.ai/color-palette-generator/README.md
+++ b/july-2025/xpander.ai/color-palette-generator/README.md
@@ -1,0 +1,47 @@
+# Color Palette Generator
+
+This web app generates a random color palette of five colors and allows users to copy hex codes.
+
+## Usage
+
+1. Open `index.html` in a web browser.
+2. Click the "Generate Palette" button to create a new set of colors.
+3. Click on any hex code to copy it to your clipboard.
+
+## AI Authorship
+
+> **This application was autonomously created by an AI agent.**
+
+## AI Stack
+
+**Type**: `single-agent`
+
+**Agent Card**:
+```json
+{
+  "name": "Xpander Coding Agent",
+  "description": "An AI agent for designing and implementing web applications using vanilla JavaScript, HTML, and CSS.",
+  "url": "https://xpander.ai",
+  "provider": {
+    "organization": "Xpander"
+  },
+  "version": "1.0.0",
+  "authentication": {
+    "schemes": ["none"],
+    "credentials": "Not applicable"
+  },
+  "skills": [
+    {
+      "id": "web-development",
+      "name": "Web Development",
+      "description": "Creates interactive web applications with HTML, CSS, and JavaScript."
+    }
+  ]
+}
+```
+
+**Models**: GPT-4
+
+**Framework**: OpenAI API
+
+**Platform**: xpander.ai

--- a/july-2025/xpander.ai/color-palette-generator/index.html
+++ b/july-2025/xpander.ai/color-palette-generator/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Color Palette Generator</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Color Palette Generator</h1>
+        <div class="palette" id="palette"></div>
+        <button id="generate">Generate Palette</button>
+    </div>
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/july-2025/xpander.ai/color-palette-generator/script.js
+++ b/july-2025/xpander.ai/color-palette-generator/script.js
@@ -1,0 +1,30 @@
+function getRandomColor() {
+    const hex = Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0');
+    return `#${hex}`;
+}
+
+function generatePalette(num = 5) {
+    const paletteContainer = document.getElementById('palette');
+    paletteContainer.innerHTML = '';
+    for (let i = 0; i < num; i++) {
+        const color = getRandomColor();
+        const colorDiv = document.createElement('div');
+        colorDiv.className = 'color';
+        colorDiv.style.background = color;
+
+        const hexDiv = document.createElement('div');
+        hexDiv.className = 'hex';
+        hexDiv.textContent = color;
+        hexDiv.addEventListener('click', () => {
+            navigator.clipboard.writeText(color);
+            hexDiv.textContent = 'Copied!';
+            setTimeout(() => { hexDiv.textContent = color; }, 1000);
+        });
+
+        colorDiv.appendChild(hexDiv);
+        paletteContainer.appendChild(colorDiv);
+    }
+}
+
+document.getElementById('generate').addEventListener('click', () => generatePalette());
+window.addEventListener('DOMContentLoaded', () => generatePalette());

--- a/july-2025/xpander.ai/color-palette-generator/style.css
+++ b/july-2025/xpander.ai/color-palette-generator/style.css
@@ -1,0 +1,64 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    background: #f0f0f0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.container {
+    text-align: center;
+}
+
+.palette {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    gap: 10px;
+    margin: 20px 0;
+}
+
+.color {
+    position: relative;
+    height: 100px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.color:hover {
+    transform: scale(1.05);
+}
+
+.hex {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(255,255,255,0.7);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    cursor: pointer;
+}
+
+#generate {
+    padding: 10px 20px;
+    font-size: 1em;
+    border: none;
+    border-radius: 4px;
+    background: #333;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+#generate:hover {
+    background: #555;
+}


### PR DESCRIPTION
This PR adds a new color palette generator web app to the repository. The app is built with vanilla HTML, CSS, and JavaScript, and allows users to generate random color palettes and copy hex codes. All code is contained in the new folder `color-palette-generator` in the repo root. The UI is clean and responsive, and no frameworks are used.